### PR TITLE
Use OS specific path separator for local paths

### DIFF
--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -355,7 +355,7 @@ func runMonitorItemUpload(cmd *cobra.Command, args []string) error {
 	switch mode := pathStat.Mode(); {
 	case mode.IsDir():
 		// Upload tree to remote
-		localPathClean := strings.TrimRight(localPath, "/") + "/"
+		localPathClean := strings.TrimRight(localPath, string(os.PathSeparator)) + string(os.PathSeparator)
 		remotePathClean := strings.TrimRight(remotePath, "/") + "/"
 
 		filesParams := make([]uploadParams, 0)


### PR DESCRIPTION
Uploading folders using e.g. fails on windows due to wrong path separator:
```
vt monitor upload ..\buildtools\vt-cli\2020.2.3.52 /test1/
```