### PR TITLE
feat(scan): Add a flag to wait for analysis completion

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -182,6 +182,7 @@ func NewScanFileCmd() *cobra.Command {
 	addThreadsFlag(cmd.Flags())
 	addOpenInVTFlag(cmd.Flags())
 	addWaitForCompletionFlag(cmd.Flags())
+	addIncludeExcludeFlags(cmd.Flags())
 	cmd.MarkZshCompPositionalArgumentFile(1)
 
 	return cmd

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -43,22 +43,27 @@ func waitForAnalysisResults(cli *utils.APIClient, analysisId string) (*vt.Object
 	defer ticker.Stop()
 	ctx, cancel := context.WithTimeout(context.Background(), TIMEOUT_LIMIT)
 	defer cancel()
+	i := 0
 
 	for {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case <-ticker.C:
+			fmt.Printf("\rWaiting for analysis completion... %d", i)
+			i += 1
 			if obj, err := cli.GetObject(vt.URL(fmt.Sprintf("analyses/%s", analysisId))); err != nil {
 				// if the API returned an error 503 (transient error) retry; otherwise just return
 				//the error to the user
 				if e, ok := err.(*vt.Error); ok && e.Code == "TransientError" {
 					time.Sleep(1 * time.Second)
 				} else {
+					fmt.Print("\n")
 					return nil, fmt.Errorf("error retrieving analysis result: %v", err)
 				}
 
 			} else if status, _ := obj.Get("status"); status == "completed" {
+				fmt.Print("\n")
 				return obj, nil
 			}
 		}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -107,7 +107,7 @@ var scanFileCmdHelp = `Scan one or more files.
 This command receives one or more file paths and uploads them to VirusTotal for
 scanning. It returns the file paths followed by their corresponding analysis IDs.
 You can use the "vt analysis" command for retrieving information about the
-analyses or you can use the waitForCompletion flag to see the results when the
+analyses or you can use the --wait flag to see the results when the
 analysis is completed.
 
 If the command receives a single hypen (-) the file paths are read from the standard
@@ -201,7 +201,7 @@ var scanURLCmdHelp = `Scan one or more URLs.
 
 This command receives one or more URLs and scan them. It returns the URLs followed
 by their corresponding analysis IDs. You can use the "vt analysis" command for
-retrieving information about the analyses or you can use the waitForCompletion
+retrieving information about the analyses or you can use the --wait
 flag to see the results when the analysis is completed.
 
 If the command receives a single hypen (-) the URLs are read from the standard

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -66,7 +66,13 @@ func waitForAnalysisResults(cli *utils.APIClient, analysisId string, ds *utils.D
 
 			} else if status, _ := obj.Get("status"); status == "completed" {
 				ds.Progress = ""
-				return obj, nil
+				// request the full object report and return it instead of just
+				// the analysis results
+				if report, e := cli.GetObject(vt.URL(fmt.Sprintf("analyses/%s/item", analysisId))); e != nil {
+					return nil, e
+				} else {
+					return report, nil
+				}
 			}
 		}
 	}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -30,9 +30,9 @@ const (
 	// Poll frequency defines the interval in which requests are sent to the
 	// VT API to check if the analysis is completed.
 	POLL_FREQUENCY = 10 * time.Second
-	// Timeout limit defines the maximum amount of seconds to wait for an
+	// Timeout limit defines the maximum amount of minutes to wait for an
 	// analysis' results
-	TIMEOUT_LIMIT = 120 * time.Second
+	TIMEOUT_LIMIT = 10 * time.Minute
 )
 
 // waitForAnalysisResults calls every pollFrequency seconds to the VT API and

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -53,7 +53,7 @@ func waitForAnalysisResults(cli *utils.APIClient, analysisId string, ds *utils.D
 			return nil, ctx.Err()
 		case <-ticker.C:
 			ds.Progress = fmt.Sprintf("Waiting for analysis completion...%s", strings.Repeat(".", i))
-			i += 1
+			i++
 			if obj, err := cli.GetObject(vt.URL(fmt.Sprintf("analyses/%s", analysisId))); err != nil {
 				// If the API returned an error 503 (transient error) retry; otherwise just return
 				// the error to the user.
@@ -61,16 +61,11 @@ func waitForAnalysisResults(cli *utils.APIClient, analysisId string, ds *utils.D
 					ds.Progress = ""
 					return nil, fmt.Errorf("error retrieving analysis result: %v", err)
 				}
-
 			} else if status, _ := obj.Get("status"); status == "completed" {
 				ds.Progress = ""
 				// Request the full object report and return it instead of just
 				// the analysis results.
-				if report, e := cli.GetObject(vt.URL(fmt.Sprintf("analyses/%s/item", analysisId))); e != nil {
-					return nil, e
-				} else {
-					return report, nil
-				}
+				return cli.GetObject(vt.URL(fmt.Sprintf("analyses/%s/item", analysisId)))
 			}
 		}
 	}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -39,6 +39,7 @@ const (
 // checks whether an analysis is completed or not. When the analysis is completed
 // it is returned.
 func waitForAnalysisResults(cli *utils.APIClient, analysisId string) (*vt.Object, error) {
+	fmt.Print("Waiting for analysis completion...")
 	ticker := time.NewTicker(POLL_FREQUENCY)
 	defer ticker.Stop()
 	ctx, cancel := context.WithTimeout(context.Background(), TIMEOUT_LIMIT)
@@ -64,7 +65,11 @@ func waitForAnalysisResults(cli *utils.APIClient, analysisId string) (*vt.Object
 
 			} else if status, _ := obj.Get("status"); status == "completed" {
 				fmt.Print("\n")
-				return obj, nil
+				if report, e := cli.GetObject(vt.URL(fmt.Sprintf("analyses/%s/item", analysisId))); e != nil {
+					return nil, e
+				} else {
+					return report, nil
+				}
 			}
 		}
 	}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -39,7 +39,6 @@ const (
 // checks whether an analysis is completed or not. When the analysis is completed
 // it is returned.
 func waitForAnalysisResults(cli *utils.APIClient, analysisId string) (*vt.Object, error) {
-	fmt.Print("Waiting for analysis completion...")
 	ticker := time.NewTicker(POLL_FREQUENCY)
 	defer ticker.Stop()
 	ctx, cancel := context.WithTimeout(context.Background(), TIMEOUT_LIMIT)
@@ -65,11 +64,7 @@ func waitForAnalysisResults(cli *utils.APIClient, analysisId string) (*vt.Object
 
 			} else if status, _ := obj.Get("status"); status == "completed" {
 				fmt.Print("\n")
-				if report, e := cli.GetObject(vt.URL(fmt.Sprintf("analyses/%s/item", analysisId))); e != nil {
-					return nil, e
-				} else {
-					return report, nil
-				}
+				return obj, nil
 			}
 		}
 	}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/VirusTotal/vt-cli/utils"
@@ -39,18 +40,19 @@ const (
 // checks whether an analysis is completed or not. When the analysis is completed
 // it is returned.
 func waitForAnalysisResults(cli *utils.APIClient, analysisId string) (*vt.Object, error) {
+	fmt.Print("\rWaiting for analysis completion...")
 	ticker := time.NewTicker(POLL_FREQUENCY)
 	defer ticker.Stop()
 	ctx, cancel := context.WithTimeout(context.Background(), TIMEOUT_LIMIT)
 	defer cancel()
-	i := 0
+	i := 1
 
 	for {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case <-ticker.C:
-			fmt.Printf("\rWaiting for analysis completion... %d", i)
+			fmt.Printf("\rWaiting for analysis completion...%s", strings.Repeat(".", i))
 			i += 1
 			if obj, err := cli.GetObject(vt.URL(fmt.Sprintf("analyses/%s", analysisId))); err != nil {
 				// if the API returned an error 503 (transient error) retry; otherwise just return


### PR DESCRIPTION
closes #15

It checks the analysis status every second and has a timeout of 2 minutes.

Sample of usage:

```shellsession
$ ./build/vt scan file -w ~/Downloads/oliver.jpg -i _id,last_analysis_stats,type_description
- _id: "80ce08d3295a41fe3997a40f3891b124626635ad367b1cd3c3eec334d10429a0"
  last_analysis_stats: 
    confirmed-timeout: 0
    failure: 0
    harmless: 0
    malicious: 0
    suspicious: 0
    timeout: 0
    type-unsupported: 14
    undetected: 59
  type_description: "JPEG"
```