### PR TITLE
CI: bump workflow version, fix Node 12 deprecation warning in Action runs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
       - name: Build
         run: make build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,8 +10,8 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
       - id: get_version
         run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
       - name: Install dependencies


### PR DESCRIPTION
## Changes

- Bump the `actions/checkout` version from `v2` (Node 12) to `v3` (Node 16). [as Node 12 actions have been deprecated since last year and it has been removed recently]
- Bump `actions/setup-go` from `v2`, `v3` to `v4` as the new releases add major features and support for caching (increasing the overall performance of the workflow).