### PR TITLE
fix: fix typo

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -55,7 +55,7 @@ func addProxyFlag(flags *pflag.FlagSet) {
 	flags.String(
 		"proxy", "",
 		"HTTP proxy")
-	flags.MarkHidden("host")
+	flags.MarkHidden("proxy")
 }
 
 func addIncludeExcludeFlags(flags *pflag.FlagSet) {


### PR DESCRIPTION
`host` flag is already hidden by [addHostFlag](https://github.com/VirusTotal/vt-cli/blob/master/cmd/cmd.go#L47-L52) and so I believe `flags.MarkHidden("host")` in the `addProxyFlag` func is a typo.