### PR TITLE
fix: Crash occurs when doing scan against a directory that is denied [#125]

### DIFF
--- a/utils/file_utils.go
+++ b/utils/file_utils.go
@@ -14,6 +14,8 @@
 package utils
 
 import (
+	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -30,14 +32,20 @@ func NewFileDirReader(fileDir string, recursive bool, maxDepth int) (*StringArra
 	var filePaths []string
 	rootDepth := pathDepth(fileDir)
 
+	var errs []error
+
 	// filePaths is safely appended within WalkDir because WalkDir executes the callback sequentially.
 	// No race conditions occur in this implementation, even with slice reallocation.
 	err := filepath.WalkDir(fileDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return err
+			errs = append(errs, fmt.Errorf("%s: %w", path, err))
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
 		}
 
-		if !d.IsDir() {
+		if d != nil && !d.IsDir() {
 			filePaths = append(filePaths, path)
 			return nil
 		}
@@ -54,9 +62,10 @@ func NewFileDirReader(fileDir string, recursive bool, maxDepth int) (*StringArra
 	})
 
 	if err != nil {
-		return nil, err
+		errs = append(errs, err)
 	}
-	return &StringArrayReader{strings: filePaths}, nil
+
+	return &StringArrayReader{strings: filePaths}, errors.Join(errs...)
 }
 
 // pathDepth returns the depth of a given path by counting its components.

--- a/utils/file_utils_test.go
+++ b/utils/file_utils_test.go
@@ -169,19 +169,19 @@ func Test_NewFileDirReader_Error(t *testing.T) {
 	t.Parallel()
 
 	rootDir := t.TempDir()
-	noPerm := os.FileMode(0000)
-	if err := os.WriteFile(filepath.Join(rootDir, "a.txt"), []byte("hello world!"), noPerm); err != nil {
+	rwxPerm := os.FileMode(0755)
+	if err := os.WriteFile(filepath.Join(rootDir, "a.txt"), []byte("hello world!"), rwxPerm); err != nil {
 		t.Fatalf("unexpected error while WriteFile %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(rootDir, "z.txt"), []byte("hello world!"), noPerm); err != nil {
+	if err := os.WriteFile(filepath.Join(rootDir, "z.txt"), []byte("hello world!"), rwxPerm); err != nil {
 		t.Fatalf("unexpected error while WriteFile %v", err)
 	}
 	path := filepath.Join(rootDir, "sub")
+	noPerm := os.FileMode(0000)
 	if err := os.Mkdir(path, noPerm); err != nil {
 		t.Fatalf("unexpected error while Mkdir %v", err)
 	}
 
-	rwxPerm := os.FileMode(0755)
 	path = filepath.Join(rootDir, "sub_2")
 	if err := os.Mkdir(path, rwxPerm); err != nil {
 		t.Fatalf("unexpected error while Mkdir %v", err)

--- a/utils/file_utils_test.go
+++ b/utils/file_utils_test.go
@@ -173,18 +173,49 @@ func Test_NewFileDirReader_Error(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(rootDir, "a.txt"), []byte("hello world!"), noPerm); err != nil {
 		t.Fatalf("unexpected error while WriteFile %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(rootDir, "z.txt"), []byte("hello world!"), noPerm); err != nil {
+		t.Fatalf("unexpected error while WriteFile %v", err)
+	}
 	path := filepath.Join(rootDir, "sub")
 	if err := os.Mkdir(path, noPerm); err != nil {
 		t.Fatalf("unexpected error while Mkdir %v", err)
 	}
-	_, err := NewFileDirReader(rootDir, false, 10)
+
+	rwxPerm := os.FileMode(0755)
+	path = filepath.Join(rootDir, "sub_2")
+	if err := os.Mkdir(path, rwxPerm); err != nil {
+		t.Fatalf("unexpected error while Mkdir %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(path, "www.txt"), []byte("hello world!"), rwxPerm); err != nil {
+		t.Fatalf("unexpected error while WriteFile %v", err)
+	}
+
+	sr, err := NewFileDirReader(rootDir, false, 10)
 	if err != nil {
 		t.Errorf("unexpected error while NewFileDirReader err:%v", err)
 	}
-	_, err = NewFileDirReader(rootDir, true, 10)
+
+	sr, err = NewFileDirReader(rootDir, true, 10)
 	if !strings.Contains(err.Error(), "permission denied") {
 		t.Errorf("unexpected error permissions denied message got:%v", err.Error())
 	}
+
+	if diff := cmp.Diff(
+		&StringArrayReader{
+			strings: []string{
+				filepath.Join(rootDir, "a.txt"),
+				// note we are ignoring, and not getting back sub permission denied directory
+				filepath.Join(rootDir, "sub_2/www.txt"),
+				filepath.Join(rootDir, "z.txt"),
+			},
+		},
+		sr,
+		cmp.AllowUnexported(StringArrayReader{}),
+	); diff != "" {
+		t.Errorf("unexpected StringArrayReader mismatch (-want +got):\n%s", diff)
+	}
+
 }
 
 func Test_pathDepth(t *testing.T) {


### PR DESCRIPTION
## Description

https://github.com/VirusTotal/vt-cli/issues/125

TL;DR: Re expected behavior, as discussed in the issue [here](https://github.com/VirusTotal/vt-cli/issues/125#issuecomment-3928174404): even if we encounter errors while reading files or directories, we continue processing what can be read for scanning.

----

There is an existing bug that crashes the application at `utils/string_reader.go:46` when a *StringArrayReader object is received. The issue arises because implementations were receiving errors as expected and sometimes a nil StringArrayReader. However, code that follows this utility, such as file/directory reading logic, does not properly verify errors before using the `*StringArrayReader`.

In my fix, I ensure that the function always returns a non-empty StringArrayReader containing file strings. Any errors encountered during processing are collected and returned separately, while invalid or problematic files/directories are ignored. This guarantees that downstream code always has a valid StringArrayReader, even if it does not perform thorough error checking.

**Note: A more comprehensive refactor is recommended in the future, including improving error handling and adding unit tests across the repository, but this will require additional effort.**

## Testing

1. Unit testing: Unit tests covering reading 

2. Manual Build Testing (macOS): Verified the new behavior when building multiple subdirectories and files with restricted permissions. For example, at the root, there are files a, b, c, d, z and subdirectories sub and sub_2. When running scan -r, the file c is permission-denied, and the directory sub_2 is skipped, while all other accessible files and directories are processed correctly.

<img width="270" height="177" alt="image" src="https://github.com/user-attachments/assets/e54de177-c1d3-4bf1-a8d0-ff338bec56bc" />


4. Compiled in all architectures `make all`
