### PR TITLE
fix: Improving makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,21 +5,23 @@ BINARY=./build/vt
 LDFLAGS=-ldflags "-X github.com/VirusTotal/vt-cli/cmd.Version=${VERSION}"
 
 # Builds the project
+.PHONY: build
 build:
 	go build ${LDFLAGS} -o ${BINARY} ./vt/main.go
 
 # Installs our project: copies binaries
+.PHONY: install
 install:
 	go install ${LDFLAGS} github.com/VirusTotal/vt-cli/vt
 
 # Build the project for multiple architectures
+.PHONY: all
 all:
 	gox ${LDFLAGS} \
 	-osarch="linux/amd64 linux/386 windows/amd64 windows/386 darwin/amd64 freebsd/amd64 freebsd/386" \
 	-output "build/{{.OS}}/{{.Arch}}/{{.Dir}}" github.com/VirusTotal/vt-cli/vt
 
 # Cleans our project: deletes binaries
+.PHONY: clean
 clean:
 	rm -rf ./build
-
-.PHONY: clean install


### PR DESCRIPTION
## Description

Adding .PHONY to all Makefile commands. .PHONY tells make that a target does not represent a real file, but rather a command we want to execute (e.g. build). This prevents issues if a file or directory with the same name exists.

I’m also following a common pattern I’ve used in other projects: declaring .PHONY directly next to each target instead of grouping all .PHONY declarations at the bottom. This makes it easier to notice and reduces the chance that new targets are added without being marked as .PHONY.
